### PR TITLE
Fix: Decouple head pitch from body rotation for multiplayer avatars

### DIFF
--- a/index.html
+++ b/index.html
@@ -6010,9 +6010,17 @@ function activateHost() {
                             avatar.position.copy(interpolatedPosition);
 
                             // Interpolate rotation using quaternions for smooth slerp
-                            const prevQuaternion = new THREE.Quaternion().setFromEuler(new THREE.Euler(userState.prevPitch, userState.prevYaw, 0, 'YXZ'));
-                            const targetQuaternion = new THREE.Quaternion().setFromEuler(new THREE.Euler(userState.targetPitch, userState.targetYaw, 0, 'YXZ'));
+                            const prevQuaternion = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, userState.prevYaw, 0, 'YXZ'));
+                            const targetQuaternion = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, userState.targetYaw, 0, 'YXZ'));
                             avatar.quaternion.slerpQuaternions(prevQuaternion, targetQuaternion, alpha);
+
+                            // Interpolate pitch for head separately
+                            if (userState.prevPitch !== undefined) {
+                                const interpolatedPitch = userState.prevPitch + (userState.targetPitch - userState.prevPitch) * alpha;
+                                avatar.children[3].rotation.set(interpolatedPitch, 0, 0);
+                            } else {
+                                avatar.children[3].rotation.set(userState.targetPitch, 0, 0);
+                            }
 
                         } else if (userState.targetX !== undefined) {
                              // If no previous state, just jump to target


### PR DESCRIPTION
Previously, the entire avatar body would pitch up and down with the camera, and the head would pitch an additional amount, resulting in an exaggerated and unnatural "double-pitch" effect.

This commit modifies the multiplayer avatar update logic to correctly separate head and body rotation:

1.  The body's rotation quaternion is now calculated using only the yaw component, ensuring it only turns left and right.
2.  The pitch component is applied directly to the head object (`avatar.children[3]`) and is interpolated for smoother animation.

This change makes remote player avatars behave like the single-player avatar, where the body remains upright while the head tilts to follow the camera's pitch.