### PR TITLE
Fix world load hang by deferring and throttling chunk meshing

### DIFF
--- a/index.html
+++ b/index.html
@@ -3478,9 +3478,8 @@ self.onmessage = async function(e) {
                 var wrappedCz = modWrap(dcz, chunksPerSide);
                 var chunk = this.getChunk(wrappedCx, wrappedCz);
                 if (!chunk.generated) this.generateChunk(chunk);
-                if (chunk.needsRebuild || !chunk.mesh) this.buildChunkMesh(chunk);
                 index++;
-                setTimeout(processNext.bind(this), 333);
+                setTimeout(processNext.bind(this), 33);
             }
             processNext.call(this);
         };
@@ -3530,11 +3529,15 @@ self.onmessage = async function(e) {
             });
 
             var needed = new Set();
+            var built = 0;
             for (const chunkInfo of neededChunks) {
                 var ch = this.getChunk(chunkInfo.cx, chunkInfo.cz);
                 needed.add(ch.key);
                 if (!ch.generating && !ch.generated) this.generateChunk(ch);
-                if (ch.generated && (ch.needsRebuild || !ch.mesh)) this.buildChunkMesh(ch);
+                if (ch.generated && (ch.needsRebuild || !ch.mesh) && built < 2) {
+                    this.buildChunkMesh(ch);
+                    built++;
+                }
             }
 
             for (var peerUser in userPositions) {
@@ -7775,7 +7778,7 @@ self.onmessage = async function(e) {
                     if (healthElement) healthElement.innerText = player.health;
                     var scoreElement = document.getElementById('score');
                     if (scoreElement) scoreElement.innerText = player.score;
-                    await initServers();
+                    initServers(); // Do not await, let it run in the background
                     worker.postMessage({ type: 'sync_processed', ids: Array.from(processedMessages) });
                     startWorker();
                     setInterval(pollServers, POLL_INTERVAL);


### PR DESCRIPTION
The initial world load was causing a 3-5 second lock-up due to synchronous chunk mesh building on the main thread.

This commit addresses the issue by:
1.  Removing the blocking `await` from `initServers()` to allow server initialization to happen in the background.
2.  Deferring the building of chunk meshes from the initial `preloadChunks` function.
3.  Throttling the number of chunk meshes built per frame in the `update` function to a maximum of two.

These changes spread the heavy workload of world generation over multiple frames, resulting in a much smoother and more responsive loading experience.