### PR TITLE
Fix: Apply procedural block colors on session load

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -406,6 +406,22 @@ var previousIsSprinting = false;
                 userName = playerData.user;
                 worldSeed = playerData.seed;
 
+                // Added this to fix the styling bug
+                const colorRnd = makeSeededRandom(worldSeed + '_colors');
+                for (const blockId in BLOCKS) {
+                    if (Object.hasOwnProperty.call(BLOCKS, blockId)) {
+                        const block = BLOCKS[blockId];
+                        const baseColor = new THREE.Color(block.color);
+                        const hsv = {};
+                        baseColor.getHSL(hsv);
+                        const newHue = (hsv.h + (colorRnd() - 0.5) * 0.05);
+                        const newSat = Math.max(0.4, Math.min(0.9, hsv.s + (colorRnd() - 0.5) * 0.2));
+                        const newLight = Math.max(0.1, Math.min(0.5, hsv.l + (colorRnd() - 0.5) * 0.2));
+                        baseColor.setHSL(newHue, newSat, newLight);
+                        block.color = '#' + baseColor.getHexString();
+                    }
+                }
+
                 document.getElementById('worldNameInput').value = worldName;
                 document.getElementById('userInput').value = userName;
 


### PR DESCRIPTION
This change fixes a bug where loading a session from a save file did not apply the world-specific procedural block colors, causing a visual inconsistency compared to generating the world normally.

The fix injects the existing seed-based color generation logic into the `applySaveFile` function. This ensures that whenever a session is loaded, the block colors are deterministically recalculated based on the loaded `worldSeed`, guaranteeing a consistent appearance.