### PR TITLE
fix: Add missing block definition for GolemStone (ID 124)

### DIFF
--- a/js/chunk-manager.js
+++ b/js/chunk-manager.js
@@ -22,6 +22,7 @@ const BLOCKS = {
         121: { name: 'Laser Gun', color: '#ff0000', hand_attachable: true },
         122: { name: 'Honey', color: '#ffb74a' },
         123: { name: 'Hive', color: '#e3c27d' },
+        124: { name: 'GolemStone', color: '#4a4a4a' },
         125: { name: 'Emerald', color: '#00ff7b' },
         126: { name: 'Green Laser Gun', color: '#00ff00', hand_attachable: true },
 };

--- a/js/worker.js
+++ b/js/worker.js
@@ -92,6 +92,7 @@ const BLOCKS = {
         121: { name: 'Laser Gun', color: '#ff0000', hand_attachable: true },
         122: { name: 'Honey', color: '#ffb74a' },
         123: { name: 'Hive', color: '#e3c27d' },
+        124: { name: 'GolemStone', color: '#4a4a4a' },
         125: { name: 'Emerald', color: '#00ff7b' },
         126: { name: 'Green Laser Gun', color: '#00ff00', hand_attachable: true },
 };


### PR DESCRIPTION
Volcano worlds were crashing during chunk generation due to a `TypeError` in `createBlockTexture`. This was caused by the terrain generator in the web worker creating a block with ID 124 ("Iron Ore Placeholder"), which was not defined in the `BLOCKS` constants.

This commit adds a definition for block ID 124, now named `GolemStone`, to the `BLOCKS` constants in both `js/chunk-manager.js` and `js/worker.js`. This ensures that the rendering engine can find a valid color and other properties for the block, resolving the fatal crash.