### PR TITLE
fix: Correct teleport button behavior in user modal

### DIFF
--- a/js/web-rtc.js
+++ b/js/web-rtc.js
@@ -917,9 +917,12 @@ function openUsersModal() {
         if (n !== userName) {
             a = !0, console.log("[MODAL] Rendering peer:", n);
             var i = calculateSpawnPoint(n + "@" + worldName);
-            (h = document.createElement("div")).style.display = "flex", h.style.gap = "8px", h.style.alignItems = "center", h.style.marginTop = "8px", (f = document.createElement("div")).innerText = n + " (Connected) at (" + Math.floor(i.x) + ", " + Math.floor(i.y) + ", " + Math.floor(i.z) + ")", (m = document.createElement("button")).innerText = "Visit Spawn", m.onclick = function () {
-                console.log("[MODAL] Teleporting to spawn of:", n), respawnPlayer(i.x, 100, i.z), t.style.display = "none", isPromptOpen = !1
-            }, h.appendChild(f), h.appendChild(m), o.appendChild(h)
+            (h = document.createElement("div")).style.display = "flex", h.style.gap = "8px", h.style.alignItems = "center", h.style.marginTop = "8px", (f = document.createElement("div")).innerText = n + " (Connected) at (" + Math.floor(i.x) + ", " + Math.floor(i.y) + ", " + Math.floor(i.z) + ")", (m = document.createElement("button")).innerText = "Visit Spawn",
+                function (e, o) {
+                    m.onclick = function () {
+                        console.log("[MODAL] Teleporting to spawn of:", e), respawnPlayer(o.x, 100, o.z), t.style.display = "none", isPromptOpen = !1
+                    }
+                }(n, i), h.appendChild(f), h.appendChild(m), o.appendChild(h)
         }
     }
     var c = document.createElement("h4");


### PR DESCRIPTION
The "Visit Spawn" button in the online players modal was not teleporting players to the correct coordinates due to a closure issue in the `for` loop that generates the player list. The `onclick` handler was capturing a reference to the loop variables, causing all buttons to use the values from the final iteration.

This commit fixes the bug by wrapping the `onclick` handler assignment in an Immediately Invoked Function Expression (IIFE). This creates a new scope for each iteration, ensuring that each button's event handler is bound to the correct player and spawn point data.