### PR TITLE
fix(multiplayer): Remove client-side damage cooldown

### DIFF
--- a/js/web-rtc.js
+++ b/js/web-rtc.js
@@ -347,7 +347,7 @@ function setupDataChannel(e, t) {
                     isHost && handlePlayerHit(s);
                     break;
                 case "player_damage":
-                    Date.now() - lastDamageTime > 400 && (player.health = Math.max(0, player.health - (s.damage || 1)), lastDamageTime = Date.now(), document.getElementById("health").innerText = player.health, updateHealthBar(), "lava" === s.attacker ? addMessage("Burning in lava! HP: " + player.health, 1e3) : addMessage("Hit by " + s.attacker + "! HP: " + player.health, 1e3), flashDamageEffect(), safePlayAudio(soundHit), void 0 !== s.kx && void 0 !== s.kz && (player.vx += s.kx, player.vz += s.kz), player.health <= 0 && handlePlayerDeath());
+                    (player.health = Math.max(0, player.health - (s.damage || 1)), lastDamageTime = Date.now(), document.getElementById("health").innerText = player.health, updateHealthBar(), "lava" === s.attacker ? addMessage("Burning in lava! HP: " + player.health, 1e3) : addMessage("Hit by " + s.attacker + "! HP: " + player.health, 1e3), flashDamageEffect(), safePlayAudio(soundHit), void 0 !== s.kx && void 0 !== s.kz && (player.vx += s.kx, player.vz += s.kz), player.health <= 0 && handlePlayerDeath());
                     break;
                 case "add_score":
                     player.score += s.amount || 0, document.getElementById("score").innerText = player.score, addMessage(`+${s.amount} score`, 1500);


### PR DESCRIPTION
Removes the redundant client-side damage cooldown check (`Date.now() - lastDamageTime > 400`) from the `player_damage` message handler in `js/web-rtc.js`.

In the host-authoritative model, the host is responsible for determining when damage occurs and applying any necessary cooldowns. The client-side check was preventing valid damage messages from the host from being processed, causing a bug where clients would not take damage from environmental sources like lava.

This change ensures that clients correctly process all damage events sent by the host, resolving the desynchronization issue.