### PR TITLE
feat: Implement block strength with visual and audio effects

### DIFF
--- a/js/web-rtc.js
+++ b/js/web-rtc.js
@@ -474,7 +474,18 @@ function setupDataChannel(e, t) {
                         }
                     break;
                 case "remove_peer":
-                    s.username && cleanupPeer(s.username)
+                    s.username && cleanupPeer(s.username);
+                    break;
+                case "block_hit":
+                    if (isHost) {
+                        removeBlockAt(s.x, s.y, s.z);
+                    }
+                    break;
+                case "block_damaged":
+                    if (!isHost) {
+                        updateBlockDamageVisuals(s.x, s.y, s.z, s.hits);
+                    }
+                    break;
             }
         } catch (e) {
             console.error(`[WEBRTC] Failed to process message from ${t}:`, e)


### PR DESCRIPTION
- Adds a `strength` property to each block type, determining the number of hits required to break it.
- Implements a visual cracking effect that becomes more pronounced with each hit on a block.
- Adds three new sound effects (`pick0.ogg`, `pick1.ogg`, `pick2.ogg`) that play randomly when a block is hit but not broken.
- Introduces a particle explosion animation when a block is destroyed, showing mini-blocks of the same texture falling with gravity.
- All new features are synchronized in multiplayer. Clients send `block_hit` messages to the host, and the host broadcasts `block_damaged` messages to keep all players' visuals in sync.