### PR TITLE
fix: Correctly attribute block drops in multiplayer

### DIFF
--- a/js/web-rtc.js
+++ b/js/web-rtc.js
@@ -478,8 +478,11 @@ function setupDataChannel(e, t) {
                     break;
                 case "block_hit":
                     if (isHost) {
-                        removeBlockAt(s.x, s.y, s.z);
+                        removeBlockAt(s.x, s.y, s.z, s.username);
                     }
+                    break;
+                case "add_to_inventory":
+                    addToInventory(s.blockId, s.count, s.originSeed);
                     break;
                 case "block_damaged":
                     if (!isHost) {


### PR DESCRIPTION
This commit fixes a critical bug in multiplayer where blocks broken by a client would incorrectly appear in the host's inventory.

The `removeBlockAt` function, which is authoritative on the host, was previously adding the broken block's item drop to the local inventory by default.

This has been corrected by:
1.  Adding a `breaker` parameter to `removeBlockAt` to identify which player broke the block.
2.  Updating all calls to `removeBlockAt` (for local breaks, client-initiated breaks, and projectile breaks) to pass the correct username.
3.  Introducing a new `add_to_inventory` WebRTC message. The host now sends this message to the specific client who broke the block, ensuring they receive the item.
4.  Adding a handler for the `add_to_inventory` message on the client-side to process the item drop.

This change ensures that item drops are correctly attributed to the player who earned them, restoring correct multiplayer functionality.