### PR TITLE
feat(magician-stone): Proximity audio for videos and music symbol for…

### DIFF
--- a/js/web-rtc.js
+++ b/js/web-rtc.js
@@ -542,6 +542,18 @@ function setupDataChannel(e, t) {
                         }
                     }
                     break;
+                case "magician_stone_mute":
+                    if (s.key && magicianStones[s.key]) {
+                        const stone = magicianStones[s.key];
+                        stone.isMuted = s.isMuted;
+                        if (stone.audioElement) {
+                            stone.audioElement.muted = s.isMuted;
+                        }
+                        if (stone.videoElement) {
+                            stone.videoElement.muted = s.isMuted;
+                        }
+                    }
+                    break;
                 case "magician_stone_removed":
                     if (!isHost) {
                         const key = s.key;


### PR DESCRIPTION
… audio

This commit introduces several enhancements to the Magician Stone feature:

- Video players now have proximity-based audio, similar to the existing audio players. The volume of the video will increase as the player gets closer to the stone.
- Clicking on a video player will now mute and unmute the audio. This state is synchronized across all players in a multiplayer session.
- For audio-only files (e.g., .mp3), the Magician Stone now displays a 3D voxel music symbol instead of a screen.
- The music symbol is positioned two blocks above the stone by default.
- Clicking the music symbol will mute and unmute the audio for all players, with the state being synchronized via WebRTC.