### PR TITLE
feat: overhaul crafting menu and mobile UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -315,12 +315,84 @@
             background: var(--panel);
             padding: 14px;
             border-radius: 10px;
-            min-width: 360px;
+            width: 90%;
+            max-width: 500px;
+            max-height: 80vh;
+            display: flex;
+            flex-direction: column;
         }
 
-            #craftModal h3 {
-                margin: 0 0 8px 0;
-            }
+        #craftModal h3 {
+            margin: 0 0 8px 0;
+            text-align: center;
+            flex-shrink: 0;
+        }
+
+        #recipeList {
+            overflow-y: auto;
+            flex-grow: 1;
+            padding-right: 5px; /* for scrollbar */
+        }
+
+        .recipe-item {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 8px;
+            border-radius: 6px;
+            background: #0d1620;
+            margin-bottom: 8px;
+        }
+
+        .recipe-preview {
+            width: 40px;
+            height: 40px;
+            border-radius: 4px;
+            flex-shrink: 0;
+        }
+
+        .recipe-info {
+            flex-grow: 1;
+        }
+
+        .recipe-name {
+            font-weight: bold;
+        }
+
+        .recipe-ingredients {
+            font-size: 12px;
+            opacity: 0.8;
+            margin-top: 4px;
+        }
+
+        .recipe-status {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 5px;
+        }
+
+        .recipe-status .status-text {
+            font-size: 12px;
+            font-weight: bold;
+        }
+
+        .status-craftable {
+            color: #66ff66;
+        }
+
+        .status-not-craftable {
+            color: #ff6b6b;
+        }
+
+        .recipe-status button {
+             padding: 6px 10px;
+             border-radius: 4px;
+             background: var(--accent);
+             color: #111;
+             border: 0;
+             cursor: pointer;
+        }
 
         #inventoryModal {
             position: fixed;
@@ -404,8 +476,8 @@
 
         #mobileControls {
             position: fixed;
-            left: 12px;
-            bottom: 12px;
+            left: 20px;
+            bottom: 80px;
             z-index: 195;
             display: none;
             gap: 8px;
@@ -426,8 +498,8 @@
 
         #mobileRight {
             position: fixed;
-            right: 12px;
-            bottom: 12px;
+            right: 20px;
+            bottom: 80px;
             z-index: 195;
             display: none;
             gap: 8px;
@@ -700,13 +772,35 @@
             gap: 8px;
         }
 
-        @media (max-width:700px) {
+        .mobile-hotbar .hot-slot {
+            width: 18% !important; /* Use important to override default inline styles if necessary */
+            padding-bottom: 18% !important;
+            max-width: 48px; /* Ensure slots don't get too big on wider screens in this mode */
+            max-height: 48px;
+        }
+
+        .minimap-small {
+            width: 80px !important;
+            height: 100px !important;
+        }
+
+        .minimap-small #minimap {
+            height: 80px !important;
+        }
+
+        @media (max-width: 700px) and (orientation: portrait) {
             #mobileControls, #mobileRight {
                 display: flex;
             }
 
             #hud {
-                display: none;
+                display: none !important;
+            }
+
+            #hotbar {
+                flex-wrap: wrap;
+                justify-content: flex-start;
+                max-width: 280px; /* 5 slots * (48px width + 4px gap) */
             }
 
             #rightPanel {

--- a/index.html
+++ b/index.html
@@ -121,10 +121,10 @@
             <button id="musicMenuBtn" style="width: 100%;">Music Menu</button>
         </div>
     </div>
-    <div id="craftModal">
+    <div id="craftModal" style="display:none;">
         <h3>Crafting</h3>
         <div id="recipeList"></div>
-        <div style="margin-top:10px;text-align:right;">
+        <div style="margin-top:10px;text-align:right; flex-shrink: 0;">
             <button id="closeCraft">Close</button>
         </div>
     </div>
@@ -185,7 +185,7 @@
     </div>
     <div id="mobileRight">
         <div class="m-action" id="mJump">J</div>
-        <div class="m-action" id="mAttack">⚔</div>
+        <div class="m-action" id="mInventory">I</div>
         <div class="m-action" id="mCam">T</div>
     </div>
     <div id="crosshair">+</div>
@@ -199,6 +199,7 @@
             <button id="closePending">Close</button>
         </div>
     </div>
+    <div id="mobileModeToggle" style="position: fixed; bottom: 12px; right: 84px; z-index: 200; cursor: pointer; font-size: 24px; opacity: 0.5;">📱</div>
     <div id="tvIcon" style="position: fixed; bottom: 12px; right: 48px; z-index: 200; cursor: pointer; font-size: 24px; opacity: 0.5;">📺</div>
     <div id="cameraBtn" style="position: fixed; bottom: 12px; right: 12px; z-index: 200; cursor: pointer; font-size: 24px; opacity: 0.5;">📷</div>
     <div id="videoPlayer" style="display: none; position: fixed; bottom: 48px; right: 12px; z-index: 210; width: 320px; background: var(--panel); border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,0.6); padding: 10px; color: #fff;">


### PR DESCRIPTION
This commit introduces a major overhaul of the crafting menu and mobile UI.

The crafting menu has been redesigned to be more user-friendly and visually appealing. It now displays a preview of the craftable item, a list of required ingredients, and the crafting status. The menu also remains open after crafting an item, allowing for multiple crafts without reopening the menu.

The mobile UI has been improved to be more responsive to screen orientation. The HUD is now hidden in portrait mode, and the number of hotbar slots is reduced. A new toggle button has been added to allow users to switch to mobile mode in landscape orientation. The on-screen controls have been repositioned to prevent overlapping with other UI elements.

Finally, a double-click file selection feature has been added to the login screen's drag-and-drop area to improve usability on mobile devices.