### PR TITLE
feat: reset world on client connect and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌌 SupGalaxy v0.5.3-beta
+# 🌌 SupGalaxy v0.5.4-beta
 **SupGalaxy** is an open-source, serverless voxel world—**Minecraft-style gameplay fused with satoshi-grade decentralization**. Worlds generate from simple keyword seeds and sync globally through **IPFS + P2FK** on Bitcoin testnet3. No accounts. No servers. No gatekeepers. Just your browser and an infinite procedural cosmos.
 
 Built with ❤️ by **embii4u**, **Grok (xAI)**, **Jules**, **kattacomi**, and **ChatGPT**.  

--- a/index.html
+++ b/index.html
@@ -8,17 +8,17 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@embii4u">
     <meta name="twitter:title" content="🌌 SupGalaxy: Decentralized Voxel Adventure on Bitcoin">
-    <meta name="twitter:description" content="SupGalaxy v0.5.3-beta: an open-source voxel universe inspired by Minecraft, where every chunk can be owned, modified, and anchored on Bitcoin! Explore cosmic biomes, battle mobs, craft wonders, and multiplayer via WebRTC. No servers, just eternal on-chain worlds. A gift to the cosmos! ✨">
+    <meta name="twitter:description" content="SupGalaxy v0.5.4-beta: an open-source voxel universe inspired by Minecraft, where every chunk can be owned, modified, and anchored on Bitcoin! Explore cosmic biomes, battle mobs, craft wonders, and multiplayer via WebRTC. No servers, just eternal on-chain worlds. A gift to the cosmos! ✨">
     <meta name="twitter:image" content="https://supgalaxy.org/SupGalaxy.jpg">
     <meta name="twitter:image:alt" content="SupGalaxy thumbnail: A cosmic voxel world with starry skies, procedural terrain, and player-built structures on the blockchain.">
 
     <!-- Open Graph Meta Tags (Bonus for Facebook, LinkedIn, etc.) -->
     <meta property="og:title" content="🌌 SupGalaxy: Infinite Decentralized Voxel Adventure on Blockchain">
-    <meta property="og:description" content="SupGalaxy v0.5.3-beta: an open-source voxel universe inspired by Minecraft, where every chunk can be owned, modified, and anchored on Bitcoin! Explore cosmic biomes, battle mobs, craft wonders, and multiplayer via WebRTC. No servers, just eternal on-chain worlds. A gift to the cosmos! ✨">
+    <meta property="og:description" content="SupGalaxy v0.5.4-beta: an open-source voxel universe inspired by Minecraft, where every chunk can be owned, modified, and anchored on Bitcoin! Explore cosmic biomes, battle mobs, craft wonders, and multiplayer via WebRTC. No servers, just eternal on-chain worlds. A gift to the cosmos! ✨">
     <meta property="og:image" content="https://supgalaxy.org/SupGalaxy.jpg">
     <meta property="og:url" content="https://supgalaxy.org">
     <meta property="og:type" content="website">
-    <title>SupGalaxy v0.5.3-beta</title>
+    <title>SupGalaxy v0.5.4-beta</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -110,7 +110,7 @@
     <div id="hotbar" style="display:none;"></div>
     <div id="rightPanel" style="display:none;">
         <canvas id="minimap"></canvas>
-        <div id="versionLabel">SupGalaxy v0.5.3-beta</div>
+        <div id="versionLabel">SupGalaxy v0.5.4-beta</div>
         <div id="musicPlayer" style="margin-top: 8px; width: 100%;">
             <div id="currentTrack" style="font-size: 10px; text-align: center; color: #eaf6ff; opacity: 0.9; word-wrap: break-word;">No music loaded</div>
             <div style="display: flex; justify-content: space-around; margin-top: 4px;">

--- a/js/main.js
+++ b/js/main.js
@@ -17,7 +17,7 @@ var scene, camera, renderer, controls, meshGroup, chunkManager, sun, moon, stars
     LOAD_RADIUS = 3,
     currentLoadRadius = INITIAL_LOAD_RADIUS,
     CHUNKS_PER_SIDE = Math.floor(MAP_SIZE / CHUNK_SIZE),
-    VERSION = "SupGalaxy v0.5.3-beta", // Contributed to by Jules
+    VERSION = "SupGalaxy v0.5.4-beta", // Contributed to by Jules
     POLL_INTERVAL = 3e4,
     MAX_PEERS = 10,
     BLOCKS = {
@@ -3952,6 +3952,50 @@ function updateProximityVideo() {
     const i = proximityVideoUsers[currentProximityVideoIndex],
         l = i === userName ? localVideoStream : userVideoStreams.get(i)?.stream;
     o.srcObject !== l && (a.innerText = i, o.srcObject = l)
+}
+
+function resetWorld() {
+    addMessage(`Syncing to host's world...`, 4e3);
+    worldArchetype = null;
+
+    // Clear mobs and their meshes
+    mobs.forEach(mob => {
+        if (mob.mesh) scene.remove(mob.mesh);
+        if (mob.particles) scene.remove(mob.particles);
+    });
+    mobs = [];
+
+    // Clear volcanoes and related particles
+    volcanoes = [];
+    activeEruptions = [];
+    eruptedBlocks.forEach(block => scene.remove(block.mesh));
+    eruptedBlocks = [];
+    pebbles.forEach(pebble => scene.remove(pebble.mesh));
+    pebbles = [];
+    smokeParticles.forEach(particle => scene.remove(particle));
+    smokeParticles = [];
+
+    // Clear other world-specific data
+    hiveLocations = [];
+    flowerLocations = [];
+    torchRegistry.clear();
+    torchLights.clear();
+    torchParticles.forEach(p => scene.remove(p));
+    torchParticles.clear();
+
+    // Clear chunk data and meshes
+    chunkManager.chunks.clear();
+    meshGroup.children.forEach(disposeObject);
+    meshGroup.children = [];
+
+    // Clear world states
+    if (WORLD_STATES.has(worldName)) {
+        WORLD_STATES.get(worldName).chunkDeltas.clear();
+        WORLD_STATES.get(worldName).foreignBlockOrigins.clear();
+    }
+
+    // Reset chunk manager to re-request chunks
+    chunkManager = new ChunkManager(worldSeed);
 }
 
 function switchWorld() {

--- a/js/web-rtc.js
+++ b/js/web-rtc.js
@@ -270,15 +270,15 @@ function setupDataChannel(e, t) {
                 username: userName
             }));
 
-            if (!syncedWorlds.has(worldName)) {
-                e.send(JSON.stringify({
-                    type: "request_world_sync",
-                    world: worldName,
-                    username: userName
-                }));
-                syncedWorlds.add(worldName);
-            }
-
+        } else {
+            // This is a client connecting to a host, reset world and request sync
+            resetWorld();
+            e.send(JSON.stringify({
+                type: "request_world_sync",
+                world: worldName,
+                username: userName
+            }));
+        }
             // Sync magician stones to new player
             if (Object.keys(magicianStones).length > 0) {
                 const magicianStonesSync = {


### PR DESCRIPTION
Clients now reset their world state and request a full sync from the host upon connecting. This resolves the issue where clients would not have a fully synchronized world.

- Added a `resetWorld()` function to clear all world data.
- Called `resetWorld()` and requested a world sync from the host in `setupDataChannel()` for clients.
- Updated version number to v0.5.4-beta in `index.html`, `README.md`, and `js/main.js`.