### PR TITLE
Save to Testnet3 via IPFS

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,6 +183,10 @@
                     <div style="font-size: 16px; margin-bottom: 4px;">📦 Save Only My Changes and State</div>
                     <div style="font-size: 12px; font-weight: normal; opacity: 0.8;">Save your personal changes, inventory, and player state</div>
                 </button>
+                <button id="saveToTestnetBtn" style="padding: 16px; background: #f7931a; color: #111; border: 0; border-radius: 8px; cursor: pointer; font-weight: 700; font-size: 15px; display: none;">
+                    <div style="font-size: 16px; margin-bottom: 4px;">☁️ Save to Bitcoin Testnet3</div>
+                    <div style="font-size: 12px; font-weight: normal; opacity: 0.8;">Save your game session to IPFS via testnet3</div>
+                </button>
             </div>
             <div style="margin-top: 16px; text-align: center;">
                 <button id="closeSaveOptionsModal" style="padding: 8px 20px; background: transparent; color: #fff; border: 1px solid rgba(255,255,255,0.2); border-radius: 6px; cursor: pointer;">Cancel</button>

--- a/js/api.js
+++ b/js/api.js
@@ -39,6 +39,25 @@ async function fetchIPFSWithFallback(hash, filename = null) {
     return await fetch('https://ipfs.io/ipfs/' + hash);
 }
 
+async function uploadToIPFS(blob, filename) {
+    const formData = new FormData();
+    formData.append('file', blob, filename);
+    try {
+        const response = await fetch('https://p2fk.io/api/v0/add', {
+            method: 'POST',
+            body: formData
+        });
+        if (!response.ok) {
+            throw new Error(`Upload failed: ${response.statusText}`);
+        }
+        const data = await response.json();
+        return data.Hash;
+    } catch (e) {
+        console.error('[IPFS] Upload error:', e);
+        throw e;
+    }
+}
+
 async function GetPublicAddressByKeyword(keyword) {
     try {
         if (addressByKeywordCache.has(keyword)) return addressByKeywordCache.get(keyword);

--- a/js/main.js
+++ b/js/main.js
@@ -2964,6 +2964,14 @@ function performAttack() {
 async function downloadSession() {
     // Show the save options modal for all players (host and peer)
     isPromptOpen = true;
+    const testnetBtn = document.getElementById("saveToTestnetBtn");
+    if (testnetBtn) {
+        if (typeof S !== 'undefined' && S.priv) {
+            testnetBtn.style.display = "block";
+        } else {
+            testnetBtn.style.display = "none";
+        }
+    }
     document.getElementById("saveOptionsModal").style.display = "flex";
 }
 
@@ -2983,6 +2991,126 @@ function savePlayerChangesOnly() {
     
     // Trigger the player-specific save
     downloadSinglePlayerSession();
+}
+
+async function saveToTestnet3() {
+    // Close the modal
+    document.getElementById("saveOptionsModal").style.display = "none";
+    isPromptOpen = false;
+
+    try {
+        const worldState = getCurrentWorldState();
+        const serializableMagicianStones = {};
+        for (const key in magicianStones) {
+            if (Object.hasOwnProperty.call(magicianStones, key)) {
+                const stone = magicianStones[key];
+                if (stone.source !== 'local') continue;
+                serializableMagicianStones[key] = {
+                    x: stone.x,
+                    y: stone.y,
+                    z: stone.z,
+                    url: stone.url,
+                    width: stone.width,
+                    height: stone.height,
+                    offsetX: stone.offsetX,
+                    offsetY: stone.offsetY,
+                    offsetZ: stone.offsetZ,
+                    loop: stone.loop,
+                    autoplay: stone.autoplay,
+                    autoplayAnimation: stone.autoplayAnimation,
+                    distance: stone.distance,
+                    volume: stone.volume
+                };
+            }
+        }
+
+        const serializableChests = {};
+        for (const key in chests) {
+            if (Object.hasOwnProperty.call(chests, key)) {
+                const chest = chests[key];
+                if (chest.source !== 'local') continue;
+                serializableChests[key] = {
+                    x: chest.x,
+                    y: chest.y,
+                    z: chest.z,
+                    items: chest.items,
+                    name: chest.name || "Chest"
+                };
+            }
+        }
+
+        const playerSessionData = {
+            isHostSession: false,
+            playerData: {
+                worldName: worldName,
+                inventory: inventory,
+                hotbar: hotbar,
+                position: { x: player.position.x, y: player.position.y, z: player.position.z },
+                pitch: player.pitch,
+                yaw: player.yaw,
+                spawnPoint: spawnPoint,
+                time: time,
+                health: currentHealth,
+                magicianStones: serializableMagicianStones,
+                chests: serializableChests,
+                musicPlaylist: musicPlaylist,
+                videoPlaylist: videoPlaylist
+            },
+            deltas: Array.from(worldState.chunkDeltas.entries()).map(([chunkKey, changes]) => ({
+                chunk: chunkKey,
+                changes: Array.from(changes.entries())
+            }))
+        };
+
+        playerSessionData.hash = simpleHash(JSON.stringify(playerSessionData.playerData));
+        const jsonStr = JSON.stringify(playerSessionData);
+
+        // 100 MB limit
+        if (jsonStr.length > 100 * 1024 * 1024) {
+            addMessage("Save file > 100MB. Please use 'Save Only My Changes' and attach in Sup!?", 4000);
+            return;
+        }
+
+        addMessage("Uploading session to IPFS...", 3000);
+        const blob = new Blob([jsonStr], { type: "application/json" });
+        const filename = `${worldName}_${userName}_session_${Date.now()}.json`;
+
+        const cid = await uploadToIPFS(blob, filename);
+        const urn = `IPFS:${cid}/${filename}`;
+
+        let kwStr = `${userName}-GS`;
+        if (userName.length > 18) {
+            kwStr = `${userName.substring(0, 17)}-GS`; // max 20 chars
+        }
+        kwStr = "#" + kwStr;
+
+        addMessage("Resolving keyword address...", 3000);
+        const keywordAddr = await GetPublicAddressByKeyword(kwStr);
+        if (!keywordAddr) {
+            throw new Error("Could not resolve keyword address");
+        }
+
+        addMessage("Preparing Testnet3 transaction...", 3000);
+
+        // Since we need to broadcast a Sup!? message with URN, we construct the payload properly
+        const payload = JSON.stringify({ URN: urn, U: urn }); // standard minimal profile URN format
+
+        addMessage("Broadcasting save to Testnet3...", 3000);
+
+        const p2fkAddrs = await window.encP2FK(payload);
+        const allOuts = [ { addr: keywordAddr, amount: 546 / 1e8 } ];
+        for(const a of p2fkAddrs) {
+            allOuts.push({ addr: a, amount: 546 / 1e8 });
+        }
+
+        const txid = await window.sendManyWithWallet(allOuts);
+        addMessage(`Saved successfully! TXID: ${txid}`, 5000);
+        console.log("Save TXID:", txid);
+
+    } catch (e) {
+        console.error("Save to Testnet3 failed:", e);
+        addMessage(`Failed to save to Testnet3: ${e.message}`, 4000);
+    }
 }
 
 async function downloadHostSession() {
@@ -4975,6 +5103,8 @@ document.addEventListener("DOMContentLoaded", (async function () {
             saveFullSession(), this.blur()
         })), document.getElementById("savePlayerChangesBtn").addEventListener("click", (function () {
             savePlayerChangesOnly(), this.blur()
+        })), document.getElementById("saveToTestnetBtn").addEventListener("click", (function () {
+            saveToTestnet3(), this.blur()
         })), document.getElementById("teleportCancel").addEventListener("click", (function () {
             isPromptOpen = !1, document.getElementById("teleportModal").style.display = "none", this.blur()
         })), document.getElementById("teleportOk").addEventListener("click", (function () {

--- a/js/wallet.js
+++ b/js/wallet.js
@@ -567,6 +567,7 @@ async function signWithWallet(text) {
 window.buildP2fkRecipientsAndCost = buildP2fkRecipientsAndCost;
 window.sendManyWithWallet = sendManyWithWallet;
 window.signWithWallet = signWithWallet;
+window.encP2FK = encP2FK;
 
 function renderWalletUI(container, balance=null){
   const locked=!S.priv;
@@ -714,6 +715,7 @@ async function afterUnlock(){
   try{ S.keyring=await buildKeyring(S.priv); }catch{}
 
   // load own profile
+  let resolvedUserName = S.addr;
   try {
       if (typeof GetProfileByAddress !== 'undefined') {
           const profile = await GetProfileByAddress(S.addr);
@@ -721,9 +723,12 @@ async function afterUnlock(){
           if (userInput) {
               if (profile && profile.URN) {
                   userInput.value = profile.URN;
+                  resolvedUserName = profile.URN;
               } else {
                   userInput.value = S.addr;
               }
+          } else if (profile && profile.URN) {
+              resolvedUserName = profile.URN;
           }
       } else {
           const userInput = document.getElementById('userInput');
@@ -733,6 +738,53 @@ async function afterUnlock(){
       console.warn("Failed to get profile by address", e);
       const userInput = document.getElementById('userInput');
       if (userInput && !userInput.value) userInput.value = S.addr;
+  }
+
+  // Auto-load testnet3 saved session
+  try {
+      if (typeof GetPublicAddressByKeyword !== 'undefined' && typeof GetPublicMessagesByAddress !== 'undefined' && typeof applySaveFile === 'function') {
+          let kwStr = `${resolvedUserName}-GS`;
+          if (resolvedUserName.length > 18) {
+              kwStr = `${resolvedUserName.substring(0, 17)}-GS`;
+          }
+          kwStr = "#" + kwStr;
+
+          const keywordAddr = await GetPublicAddressByKeyword(kwStr);
+          if (keywordAddr) {
+              const messages = await GetPublicMessagesByAddress(keywordAddr, 0, 10);
+              if (messages && messages.length > 0) {
+                  // Find most recent IPFS message
+                  let latestIpfsMsg = null;
+                  for (const msg of messages) {
+                      if (msg.Message && msg.Message.URN && msg.Message.URN.startsWith("IPFS:")) {
+                          latestIpfsMsg = msg.Message.URN;
+                          break;
+                      }
+                      if (msg.Message && msg.Message.U && msg.Message.U.startsWith("IPFS:")) {
+                          latestIpfsMsg = msg.Message.U;
+                          break;
+                      }
+                  }
+
+                  if (latestIpfsMsg) {
+                      const hashStr = latestIpfsMsg.substring(5).split('/')[0];
+                      if (hashStr && typeof fetchIPFSWithFallback === 'function') {
+                          console.log("[WALLET] Found auto-save on testnet3, downloading from IPFS:", hashStr);
+                          const res = await fetchIPFSWithFallback(hashStr);
+                          if (res.ok) {
+                              const jsonText = await res.text();
+                              const parsedData = JSON.parse(jsonText);
+                              // Background load it via applySaveFile
+                              applySaveFile(parsedData, "local", null);
+                              console.log("[WALLET] Successfully applied auto-save from Testnet3.");
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  } catch(e) {
+      console.warn("Failed to auto-load testnet3 save:", e);
   }
 
   // render wallet views


### PR DESCRIPTION
This change introduces the ability to save the game state (as a .json file) to the p2fk.io API (IPFS ingress) via the Sup!? testnet3 wallet and fetch/reload it when a user unlocks their wallet. The saved file is stored on IPFS, and the CID is associated with a user-specific keyword via a p2fk message broadcast on testnet3. When a user unlocks their wallet, the app will automatically fetch the latest save file from IPFS and load it in the background.

---
*PR created automatically by Jules for task [12300020700939027622](https://jules.google.com/task/12300020700939027622) started by @embiimob*