### PR TITLE
Fix TESTNET3 WIF LOGIN button on iOS

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -5080,6 +5080,11 @@ document.addEventListener("DOMContentLoaded", (async function () {
                 wmb.style.display = "block";
                 testnetWifLoginBtn.style.display = "none";
             });
+            testnetWifLoginBtn.addEventListener("touchstart", (e) => {
+                e.preventDefault();
+                wmb.style.display = "block";
+                testnetWifLoginBtn.style.display = "none";
+            });
         }
         if (!(e && o && r)) return console.error("[SYSTEM] Login buttons or overlay not found in DOM"), void addMessage("UI initialization failed: buttons or overlay missing", 3e3);
         a ? a.addEventListener("change", (function (e) {


### PR DESCRIPTION
Fixes the unresponsiveness of the "TESTNET3 WIF LOGIN" button on iOS devices. iOS Safari often struggles with purely click-based synthetic interactions, so standardizing the event pattern with `touchstart` alongside `click` guarantees responsiveness without triggering double executions.

---
*PR created automatically by Jules for task [14246341962606207005](https://jules.google.com/task/14246341962606207005) started by @embiimob*